### PR TITLE
Chore: Update typing-extensions and mypy, bump version number

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
 -r requirements.txt
 beautifulsoup4==4.9.1
 xmlformatter==0.1.1
-mypy==0.782
+mypy==0.931
+types-requests>=2,<3
+types-python-dateutil>=2,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ python-dateutil>=2,<3
 toolz>=0.10,<1
 xmltodict>=0.12,<1.0
 requests>=2,<3
-typing-extensions>=3,<4
+typing-extensions>=4.0,<5

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='qbwc',
-    version='0.2.0',
+    version='0.2.1',
     description='QuickBooks Web Connector SDK',
     author='Tyler Lovely',
     author_email='tyler.n.lovely@gmail.com',


### PR DESCRIPTION
`types-requests` and `types-python-dateutil` were added because they were included in previous mypy versions

See https://github.com/python/mypy/issues/10632#issuecomment-860004935 and https://github.com/python/mypy/issues/10632#issuecomment-863332698

Related asana: https://app.asana.com/0/1162969677739798/1201817009971287/f